### PR TITLE
(TK-385) Use .take instead of .poll for Watchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@ Add the following dependency to your project.clj file:
 
 [![Clojars Project](https://img.shields.io/clojars/v/puppetlabs/trapperkeeper-filesystem-watcher.svg)](https://clojars.org/puppetlabs/trapperkeeper-filesystem-watcher)
 
+## Warning
+
+There is a [bug](https://bugs.openjdk.java.net/browse/JDK-8145981) in most
+released versions of OpenJDK on Linux that affect the behavior of this library.
+
+#### [tl;dr](http://blog.omega-prime.co.uk/?p=161)
+Registering new watch paths while receiving incoming events can cause the event
+path to be misreported.
+
+We encourage users to register all watch paths at start up prior to any
+expected events occuring. Currently only recursive file watching is supported,
+this means we will register any directory created by the user within an
+existing watch path. Thus creating a directory and then immediately creating
+a file or directory within the new directory will often trigger this issue.
+
+See the above linked ticket and blog post for comprehensive info, as well as
+[TK-387](https://tickets.puppetlabs.com/browse/TK-387) for our discussion
+around this topic.
+
 ## Development
 
 [![Build Status](https://travis-ci.org/puppetlabs/trapperkeeper-filesystem-watcher.svg?branch=master)](https://travis-ci.org/puppetlabs/trapperkeeper-filesystem-watcher)

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -53,7 +53,9 @@
 (defn validate-watch-options!
   [options]
   (when-not (= true (:recursive options))
-    (throw (IllegalArgumentException.(trs "Support for non-recursive directory watching not yet implemented")))))
+    (throw
+      (IllegalArgumentException.
+        (trs "Support for non-recursive directory watching not yet implemented")))))
 
 (defrecord WatcherImpl
   [watch-service callbacks]
@@ -69,8 +71,9 @@
 
 (defn create-watcher
   []
-  (map->WatcherImpl {:watch-service (.newWatchService (FileSystems/getDefault))
-                     :callbacks (atom [])}))
+  (map->WatcherImpl
+    {:watch-service (.newWatchService (FileSystems/getDefault))
+     :callbacks (atom [])}))
 
 (schema/defn watch-new-directories!
   [events :- [Event]
@@ -102,7 +105,8 @@
               (log/debug (trs "Events:\n{0}"
                               (pprint-events events)))
               (log/trace (trs "orig-events:\n{0}"
-                              (ks/pprint-to-string (map clojurize-for-logging orig-events))))
+                              (ks/pprint-to-string
+                                (map clojurize-for-logging orig-events))))
               (shutdown-on-error #(doseq [callback callbacks]
                                     (callback events)))
               (watch-new-directories! events watcher)

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -102,11 +102,13 @@
             (when-not (empty? events)
               (log/info (trs "Got {0} event(s) for watched-path {1}"
                              (count orig-events) (.watchable watch-key)))
-              (log/debug (trs "Events:\n{0}"
-                              (pprint-events events)))
-              (log/trace (trs "orig-events:\n{0}"
-                              (ks/pprint-to-string
-                                (map clojurize-for-logging orig-events))))
+              (log/debug (format "%s\n%s"
+                                 (trs "Events:")
+                                 (pprint-events events)))
+              (log/trace (format "%s\n%s"
+                                 (trs "orig-events:")
+                                 (ks/pprint-to-string
+                                   (map clojurize-for-logging orig-events))))
               (shutdown-on-error #(doseq [callback callbacks]
                                     (callback events)))
               (watch-new-directories! events watcher)

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -102,13 +102,13 @@
             (when-not (empty? events)
               (log/info (trs "Got {0} event(s) for watched-path {1}"
                              (count orig-events) (.watchable watch-key)))
-              (log/debug (format "%s\n%s"
-                                 (trs "Events:")
-                                 (pprint-events events)))
-              (log/trace (format "%s\n%s"
-                                 (trs "orig-events:")
-                                 (ks/pprint-to-string
-                                   (map clojurize-for-logging orig-events))))
+              (log/debugf "%s\n%s"
+                          (trs "Events:")
+                          (pprint-events events))
+              (log/tracef "%s\n%s"
+                          (trs "orig-events:")
+                          (ks/pprint-to-string
+                            (map clojurize-for-logging orig-events)))
               (shutdown-on-error #(doseq [callback callbacks]
                                     (callback events)))
               (watch-new-directories! events watcher)

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -53,7 +53,7 @@
 (defn validate-watch-options!
   [options]
   (when-not (= true (:recursive options))
-    (throw (IllegalArgumentException. "Support for non-recursive directory watching not yet implemented"))))
+    (throw (IllegalArgumentException.(trs "Support for non-recursive directory watching not yet implemented")))))
 
 (defrecord WatcherImpl
   [watch-service callbacks]

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service
   (:require [clojure.tools.logging :as log]
+            [puppetlabs.i18n.core :refer [trs]]
             [puppetlabs.trapperkeeper.services :as tk]
             [puppetlabs.trapperkeeper.services.protocols.filesystem-watch-service :refer :all]
             [puppetlabs.trapperkeeper.services.watcher.filesystem-watch-core :as watch-core])
@@ -20,7 +21,7 @@
       (try
         (.close (:watch-service watcher))
         (catch IOException e
-          (log/warn e "Exception while closing watch service"))))
+          (log/warn e (trs "Exception while closing watch service")))))
     context)
 
   (create-watcher

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service.clj
@@ -11,8 +11,7 @@
 
   (init
     [this context]
-    {:watchers (atom {})
-     :stopped? (atom false)})
+    {:watchers (atom {})})
 
   (start
     [this context]
@@ -20,9 +19,6 @@
 
   (stop
     [this context]
-    ;; This signals to the background thread that it should stop polling
-    ;; the filesystem for changes and terminate.
-    (reset! (:stopped? context) true)
     ;; Shut down the WatchServices
     (doseq [[watcher _] @(:watchers context)]
       (try
@@ -33,7 +29,7 @@
 
   (create-watcher
    [this]
-   (let [{:keys [watchers stopped?]} (tk/service-context this)
+   (let [{:keys [watchers]} (tk/service-context this)
          watcher (watch-core/create-watcher)]
      (swap!
        watchers
@@ -41,6 +37,5 @@
        {watcher
         (watch-core/watch!
           watcher
-          stopped?
           (partial shutdown-on-error (tk/service-id this)))})
      watcher)))

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service.clj
@@ -13,10 +13,6 @@
     [this context]
     {:watchers (atom {})})
 
-  (start
-    [this context]
-    context)
-
   (stop
     [this context]
     ;; Shut down the WatchServices

--- a/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
@@ -293,6 +293,14 @@
                test-file-nested (fs/file nested-dir "test-file")]
            (is (fs/mkdir nested-dir))
            (add-watch-dir! watcher nested-dir {:recursive true})
+           ;; There is a bug in the JDK in which we misreport the changed
+           ;; path if we are trying to register a new watch path when an event
+           ;; comes in. This sleep allows us to finish registering the
+           ;; directory before the CREATE event will come in. We are ignoring
+           ;; this for the time being as the current consumer will take the
+           ;; same action regardless of the path. See
+           ;; https://tickets.puppetlabs.com/browse/TK-387 for more details.
+           (Thread/sleep 100)
            (spit test-file-nested "foo")
            (let [events #{{:path nested-dir
                            :type :create}

--- a/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
@@ -120,6 +120,7 @@
                            :type :delete}}]
              (is (= events (wait-for-events results events)))))
          (testing "Re-creating the directory fires an event as expected"
+           (reset! results [])
            (is (fs/mkdir sub-dir))
            (let [events #{{:path sub-dir
                            :type :create}}]


### PR DESCRIPTION
Prior to this we polled each Watcher registered every second for
updated WatchKeys.

This patch moves us to use a blocking .take on each Watcher in a
backgrounded future.
