### PR TITLE
(TK-391) Handle OVERFLOW events

### DIFF
--- a/src/clj/puppetlabs/trapperkeeper/services/protocols/filesystem_watch_service.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/protocols/filesystem_watch_service.clj
@@ -6,7 +6,7 @@
   "Schema for an event on a file watched by this service."
   (schema/if #(= (:type %) :unknown)
     {:type (schema/eq :unknown)
-     :path (schema/eq nil)}
+     :path (schema/pred nil?)}
     {:type (schema/enum :create :modify :delete)
      :path File}))
 

--- a/src/clj/puppetlabs/trapperkeeper/services/protocols/filesystem_watch_service.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/protocols/filesystem_watch_service.clj
@@ -4,8 +4,11 @@
 
 (def Event
   "Schema for an event on a file watched by this service."
-  {:type (schema/enum :create :modify :delete :unknown)
-   :path File})
+  (schema/if #(= (:type %) :unknown)
+    {:type (schema/eq :unknown)
+     :path (schema/eq nil)}
+    {:type (schema/enum :create :modify :delete)
+     :path File}))
 
 (defprotocol Watcher
   (add-watch-dir! [this dir options]

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -31,7 +31,7 @@
    watch-path :- Path]
   {:type (get event-type-mappings (.kind event))
    :path (if (= StandardWatchEventKinds/OVERFLOW (.kind event))
-           (fs/file (.resolve watch-path "UNKNOWN"))
+           nil
            (-> watch-path
                (.resolve (.context event))
                fs/file))})

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -30,8 +30,7 @@
   [event :- WatchEvent
    watch-path :- Path]
   {:type (get event-type-mappings (.kind event))
-   :path (if (= StandardWatchEventKinds/OVERFLOW (.kind event))
-           nil
+   :path (when-not (= StandardWatchEventKinds/OVERFLOW (.kind event))
            (-> watch-path
                (.resolve (.context event))
                fs/file))})

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -30,9 +30,11 @@
   [event :- WatchEvent
    watch-path :- Path]
   {:type (get event-type-mappings (.kind event))
-   :path (-> watch-path
-             (.resolve (.context event))
-             fs/file)})
+   :path (if (= StandardWatchEventKinds/OVERFLOW (.kind event))
+           (fs/file (.resolve watch-path "UNKNOWN"))
+           (-> watch-path
+               (.resolve (.context event))
+               fs/file))})
 
 ;; This is quite similar to the function above but it is more a direct
 ;; conversion of the exact data available on a specific WatchEvent instance,

--- a/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
@@ -387,20 +387,19 @@
             :error))))))
 
 (deftest ^:integration overflow-test
-  (let  [watch-dir  (fs/temp-dir "overflow")
-        results  (atom  [])
-        callback  (fn  [events]  (swap! results concat events))]
+  (let [watch-dir (fs/temp-dir "overflow")
+        results (atom [])
+        callback (make-callback results)]
     (with-app-with-config
-     app watch-service-and-deps  {}
-     (let  [service  (tk-app/get-service app :FilesystemWatchService)]
+     app watch-service-and-deps {}
+     (let [service (tk-app/get-service app :FilesystemWatchService)]
        (watch! service watch-dir callback))
      ;; From experimenting the buffer seems to fill at 512 events.
      ;; However the number of events varies by operating system.
-     (let  [files  (for  [n  (range 1000)]
+     (let [files (for [n (range 1000)]
                    (fs/file watch-dir  (str n ".txt")))]
-       (doseq  [f files]
+       (doseq [f files]
          (spit f "file content"))
       (let [events #{{:type :unknown
-                      :path (fs/file watch-dir "UNKNOWN")}}]
-        (spit (fs/file watch-dir "observed.txt") "file content")
+                      :path nil}}]
         (is (= events (wait-for-events results events))))))))

--- a/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
@@ -400,15 +400,7 @@
                    (fs/file watch-dir  (str n ".txt")))]
        (doseq  [f files]
          (spit f "file content"))
-       (let  [events  (set  (map  (fn  [f]
-                                    {:type :create
-                                     :path f})
-                                  files))]
-          ;; Block for the standard wait period which should be sufficient that
-          ;; any polling interval has been reset and we won't add to an overflow
-          ;; event with our next file creation.
-          (java.lang.Thread/sleep (long wait-time)))
-      (let [events #{{:type :create
-                      :path (fs/file watch-dir "observed.txt")}}]
+      (let [events #{{:type :unknown
+                      :path (fs/file watch-dir "UNKNOWN")}}]
         (spit (fs/file watch-dir "observed.txt") "file content")
         (is (= events (wait-for-events results events))))))))

--- a/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
@@ -396,10 +396,10 @@
        (watch! service watch-dir callback))
      ;; From experimenting the buffer seems to fill at 512 events.
      ;; However the number of events varies by operating system.
-     (let [files (for [n (range 1000)]
-                   (fs/file watch-dir  (str n ".txt")))]
-       (doseq [f files]
-         (spit f "file content"))
-      (let [events #{{:type :unknown
-                      :path nil}}]
-        (is (= events (wait-for-events results events))))))))
+     ;; Once the buffer overflows we cannot reliably receive any other
+     ;; kind of event.
+     (dotimes [n 1000]
+       (spit (format "%s/%s.txt" watch-dir n) "file content"))
+     (let [events #{{:type :unknown
+                     :path nil}}]
+       (is (= events (wait-for-events results events)))))))


### PR DESCRIPTION
Previously we made no distinction for incoming overflow events.

OVERFLOW events do not have a specific context associated with their
change - only the watchable that the WatchKey was registered with.
And, an event that lacked a context would cause an NPE when
processing the event.

This patch checks to see if the event in question is an OVERFLOW event
and special cases its reporting to return as much information as
possible, without causing an NPE.
