### PR TITLE
(TK-391) Add unit test for overflow event handling

### DIFF
--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -88,6 +88,7 @@
                                           (map #(.toPath (:path %)))))))
 
 (schema/defn retrieve-events
+  :- [(schema/one WatchKey "key") (schema/one [WatchEvent] "events")]
   "Blocks until an event the watcher is concerned with has occured.
   Returns the native WatchKey and WatchEvents"
   [watcher :- (schema/protocol Watcher)]

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -87,33 +87,42 @@
                                           (filter dir-create?)
                                           (map #(.toPath (:path %)))))))
 
+(defn retrieve-events
+  [watcher]
+  (let [watch-key (.take (:watch-service watcher))
+        events (.pollEvents watch-key)]
+    [watch-key events]))
+
+(defn process-events
+  [watcher watch-key java-events shutdown-fn]
+  (let [clojure-events (map #(clojurize % (.watchable watch-key)) java-events)
+        callbacks @(:callbacks watcher)]
+    (log/info (trs "Got {0} event(s) for watched-path {1}"
+                   (count java-events) (.watchable watch-key)))
+    (log/debugf "%s\n%s"
+                (trs "Events:")
+                (pprint-events clojure-events))
+    (log/tracef "%s\n%s"
+                (trs "orig-events:")
+                (ks/pprint-to-string
+                  (map clojurize-for-logging java-events)))
+    (shutdown-fn #(doseq [callback callbacks]
+                   (callback clojure-events)))
+    (watch-new-directories! clojure-events watcher)
+    (.reset watch-key)))
+
 (schema/defn watch!
   "Creates a future and processes events for the passed in watcher.
   The future will continue until the underlying WatchService is closed."
   [watcher :- (schema/protocol Watcher)
-   shutdown-on-error :- IFn]
+   shutdown-fn :- IFn]
   (future
     (let [stopped? (atom false)]
       (while (not @stopped?)
         (try
-          (let [watch-key (.take (:watch-service watcher))
-                orig-events (.pollEvents watch-key)
-                events (map #(clojurize % (.watchable watch-key)) orig-events)
-                callbacks @(:callbacks watcher)]
+          (let [[watch-key events] (retrieve-events watcher)]
             (when-not (empty? events)
-              (log/info (trs "Got {0} event(s) for watched-path {1}"
-                             (count orig-events) (.watchable watch-key)))
-              (log/debugf "%s\n%s"
-                          (trs "Events:")
-                          (pprint-events events))
-              (log/tracef "%s\n%s"
-                          (trs "orig-events:")
-                          (ks/pprint-to-string
-                            (map clojurize-for-logging orig-events)))
-              (shutdown-on-error #(doseq [callback callbacks]
-                                    (callback events)))
-              (watch-new-directories! events watcher)
-              (.reset watch-key)))
+              (process-events watcher watch-key events shutdown-fn)))
          (catch ClosedWatchServiceException e
            (reset! stopped? true)
            (log/info (trs "Closing watcher {0}" watcher))))))))

--- a/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
@@ -419,7 +419,6 @@
           expected #{{:type :unknown :path nil}}
           callback (make-callback actual)]
       (testing "overflow events are handled normally"
-        (with-test-logging
-          (add-callback! watcher callback)
-          (watch-core/process-events! watcher watch-key events (fn [func] (func)))
-          (is (= expected (wait-for-events actual expected))))))))
+        (add-callback! watcher callback)
+        (watch-core/process-events! watcher watch-key events (fn [func] (func)))
+        (is (= expected (wait-for-events actual expected)))))))


### PR DESCRIPTION
Previously we tested overflow handling at the :integration level. This
has the unfortunate quality of requiring us to cause an error state
within Java/inotify. Up until this point we have been able to do this
easily without major repercussions on the systems that run the test.

That is not true in CI however, where we have a version of the JDK that
will not easily throw overflow events. In fact going to the lengths
required to cause an overflow event on these hosts is just as likely to
crash the JVM or fill up the disk.

This patch adds a unit test to prove our handling of overflow events is
satisfactory, and refactors the production code to make it unit
testable.
