### PR TITLE
(maint) call .reset on WatchKeys even if pollEvent returns an empty array

### DIFF
--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -94,6 +94,7 @@
   [watcher :- (schema/protocol Watcher)]
   (let [watch-key (.take (:watch-service watcher))
         events (.pollEvents watch-key)]
+    (.reset watch-key)
     [watch-key events]))
 
 (schema/defn process-events!
@@ -115,8 +116,7 @@
                   (map clojurize-for-logging orig-events)))
     (shutdown-fn #(doseq [callback callbacks]
                    (callback clojure-events)))
-    (watch-new-directories! clojure-events watcher)
-    (.reset watch-key)))
+    (watch-new-directories! clojure-events watcher)))
 
 (schema/defn watch!
   "Creates a future and processes events for the passed in watcher.


### PR DESCRIPTION
Previously we would call .reset on a WatchKey after we had processed any
events for the WatchKey. We check before processing any events to ensure
we actually got back event(s) as the docs warn us that .pollEvents could
return an empty array[1]. Consequently, if .pollEvents returns an empty
array we will never call .reset on that WatchKey. Without calling .reset
on a WatchKey the WatchKey will never be enqueued when new events happen
to it[2].

This moves the call to .reset to directly after we call .pollEvents, so
that a WatchKey is eligible to be enqueued for a new event as soon as
possible after an event takes place.
1. https://docs.oracle.com/javase/8/docs/api/java/nio/file/WatchKey.html#pollEvents--
2. https://docs.oracle.com/javase/tutorial/essential/io/notification.html
