### PR TITLE
(TK-430) Migrate to clj-parent 0.3.3 and bump i18n to 0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: lein2
+lein: 2.7.1
 jdk:
   - oraclejdk8
   - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: clojure
 lein: 2.7.1
 jdk:
   - oraclejdk8
-  - openjdk7
 script: ./ext/travisci/test.sh
 notifications:
   email: false

--- a/project.clj
+++ b/project.clj
@@ -1,24 +1,26 @@
-(def tk-version "1.4.1")
-(def ks-version "1.3.1")
-
 (defproject puppetlabs/trapperkeeper-filesystem-watcher "1.0.2-SNAPSHOT"
   :description "Trapperkeeper filesystem watcher service"
   :url "https://github.com/puppetlabs/trapperkeeper-filesystem-watcher"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
+  :min-lein-version "2.7.1"
+
+  :parent-project  {:coords [puppetlabs/clj-parent "0.3.3"]
+                    :inherit [:managed-dependencies]}
+
   :pedantic? :abort
 
   :exclusions [org.clojure/clojure]
 
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [prismatic/schema "1.1.1"]
-                 [me.raynes/fs "1.4.6"]
-                 [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/kitchensink ~ks-version]
-                 [puppetlabs/trapperkeeper-scheduler "0.0.1"]
-                 [puppetlabs/i18n "0.4.1"]]
+  :dependencies [[org.clojure/clojure]
+                 [org.clojure/tools.logging]
+                 [prismatic/schema]
+                 [me.raynes/fs]
+                 [puppetlabs/trapperkeeper]
+                 [puppetlabs/kitchensink]
+                 [puppetlabs/trapperkeeper-scheduler]
+                 [puppetlabs/i18n]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
@@ -28,12 +30,15 @@
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"]
 
-  :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper ~tk-version
+  :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper nil
                                    :classifier "test"
                                    :scope "test"]
-                                  [puppetlabs/kitchensink ~ks-version
+                                  [puppetlabs/kitchensink nil
                                    :classifier "test"
                                    :scope "test"]]}}
+
+  :plugins  [[lein-parent "0.3.1"]
+             [puppetlabs/i18n "0.6.0"]]
 
   :main puppetlabs.trapperkeeper.main
 )

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,6 @@
                  [me.raynes/fs]
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/kitchensink]
-                 [puppetlabs/trapperkeeper-scheduler]
                  [puppetlabs/i18n]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"

--- a/project.clj
+++ b/project.clj
@@ -29,10 +29,10 @@
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"]
 
-  :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper nil
+  :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper
                                    :classifier "test"
                                    :scope "test"]
-                                  [puppetlabs/kitchensink nil
+                                  [puppetlabs/kitchensink
                                    :classifier "test"
                                    :scope "test"]]}}
 


### PR DESCRIPTION
This PR migrates tk-filesystem-watcher to using clj-parent version 0.3.3
for its dependencies.  This commit also adds i18n as a plugin dependency, to
allow for message POT files to be regenerated as needed in CI.  This
commit also upgrades the lein version to 2.7.1 in the .travis.yml
file since 2.7.1 is the minimum version required for compatibility
with lein/clj-parent.

This PR also removes tk-scheduler as a dependency since none of the
production code was referencing it and the tests that were referencing it
did not seem to be needing to do so.