### PR TITLE
(maint) Reduce loglevel for events to debug from info

### DIFF
--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -124,7 +124,7 @@
   (let [callbacks @(:callbacks watcher)
         events-by-dir (group-by :watched-path events)]
     (doseq [[dir events'] events-by-dir]
-      (log/info (trs "Got {0} event(s) in directory {1}"
+      (log/debug (trs "Got {0} event(s) in directory {1}"
                    (count events') dir)))
     (log/tracef "%s\n%s"
                 (trs "Events:")


### PR DESCRIPTION
When there are a large number of events the chattiness of the logging in
tk-filesystem-watcher can be undesirable. This commit addresses that by
turning the loglevel to debug from info.