### PR TITLE
(TK-448) Add support for non-recursive directory watching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.1.0
+
+- (TK-448) (Feature release) Add support for non-recursive directory watching.
+  Adds the ability to watch only the contents of a given directory and not the
+  contents of sub-directories. Deprecates specifying this option on the
+  `add-watch-dir!` function, and adds support for it to the `create-watcher`
+  function.
+
 # 1.0.1
 
  - (maint) Fixes a long running, subtle bug in which we discard the trapperkeeper context on init

--- a/src/clj/puppetlabs/trapperkeeper/services/protocols/filesystem_watch_service.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/protocols/filesystem_watch_service.clj
@@ -14,11 +14,13 @@
      :changed-path File}))
 
 (defprotocol Watcher
-  (add-watch-dir! [this dir options]
+  (add-watch-dir! [this dir] [this dir options]
     "Given a directory on the filesystem, initiate watching of dir.  The
     watcher's callbacks will be invoked when dir changes.  Available options are:
-      * :recursive true   - If true, callbacks will be invoked when dir or any
-                            file underneath dir changes.
+      * :recursive true   - [deprecated] If true, callbacks will be invoked when dir or any file
+                            underneath dir changes. Passing options to this function is deprecated -
+                            pass `recursive` option to create-watcher function of the
+                            FilesystemWatchService protocol instead.
 
     When dir is deleted, the behavior is unspecified, left up to the
     implementation, and may be platform-specific.")
@@ -39,6 +41,12 @@
     changed file."))
 
 (defprotocol FilesystemWatchService
-  (create-watcher [this]
+  (create-watcher [this] [this options]
     "Returns a Watcher which can be used to initiate watching of a directory on
-    the filesystem."))
+    the filesystem. Available options are:
+      * :recursive (true | false) - If true, callbacks will be invoked when dir or any file
+                                    underneath dir, including files within nested directories of
+                                    dir, changes. If false, callbacks will be invoked when any
+                                    file inside of dir changes. Note that on some implementations,
+                                    modifying the contents of a directory is considered a change
+                                    to the directory itself (platform-specific)".))

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -89,12 +89,12 @@
 (defn create-watcher
   ([]
    (create-watcher {:recursive true}))
-  ([options]
+  ([{:keys [recursive] :as options}]
    (validate-watch-options! options)
    (map->WatcherImpl
      {:watch-service (.newWatchService (FileSystems/getDefault))
       :callbacks (atom [])
-      :recursive (atom (:recursive options))})))
+      :recursive (atom recursive)})))
 
 (schema/defn watch-new-directories!
   "Given an initial set of events and a watcher, identify any events that

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -54,10 +54,10 @@
 
 (defn validate-watch-options!
   [options]
-  (when-not (= true (:recursive options))
+  (when-not (instance? Boolean (:recursive options))
     (throw
       (IllegalArgumentException.
-        (trs "Support for non-recursive directory watching not yet implemented")))))
+        (trs "Must pass a boolean value for :recursive (directory watching) option")))))
 
 (defrecord WatcherImpl
   [watch-service callbacks]

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -79,7 +79,7 @@
       (throw
         (IllegalArgumentException.
           (trs "Watcher already set to :recursive {0}, cannot change to :recursive {1}"
-            @recursive (:recursive options)))))
+               @recursive (:recursive options)))))
     (watch-protocol/add-watch-dir! this dir))
 
   (add-callback!
@@ -90,9 +90,9 @@
   ([]
    (create-watcher {:recursive true}))
   ([options]
-    (validate-watch-options! options)
-    (map->WatcherImpl
-      {:watch-service (.newWatchService (FileSystems/getDefault))
+   (validate-watch-options! options)
+   (map->WatcherImpl
+     {:watch-service (.newWatchService (FileSystems/getDefault))
       :callbacks (atom [])
       :recursive (atom (:recursive options))})))
 

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -75,6 +75,8 @@
     (validate-watch-options! options)
     ;; The value of recursive was already set by `create-watcher`, possibly by specifying an option.
     ;; We validate that the option supplied to `add-watch-dir!` has the same value.
+    (log/debug
+      (trs "Passing options to `add-watch-dir!` is deprecated. Pass options to `create-watcher` instead"))
     (when-not (= @recursive (:recursive options))
       (throw
         (IllegalArgumentException.

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service.clj
@@ -26,8 +26,12 @@
 
   (create-watcher
    [this]
+   (create-watcher this {:recursive true}))
+
+  (create-watcher
+   [this options]
    (let [{:keys [watchers]} (tk/service-context this)
-         watcher (watch-core/create-watcher)
+         watcher (watch-core/create-watcher options)
          shutdown-fn (partial shutdown-on-error (tk/service-id this))]
      (watch-core/watch! watcher shutdown-fn)
      (swap! watchers conj watcher)

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service.clj
@@ -25,14 +25,14 @@
     context)
 
   (create-watcher
-   [this]
-   (create-watcher this {:recursive true}))
+    [this]
+    (create-watcher this {:recursive true}))
 
   (create-watcher
-   [this options]
-   (let [{:keys [watchers]} (tk/service-context this)
-         watcher (watch-core/create-watcher options)
-         shutdown-fn (partial shutdown-on-error (tk/service-id this))]
-     (watch-core/watch! watcher shutdown-fn)
-     (swap! watchers conj watcher)
-     watcher)))
+    [this options]
+    (let [{:keys [watchers]} (tk/service-context this)
+          watcher (watch-core/create-watcher options)
+          shutdown-fn (partial shutdown-on-error (tk/service-id this))]
+      (watch-core/watch! watcher shutdown-fn)
+      (swap! watchers conj watcher)
+      watcher)))

--- a/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
@@ -331,7 +331,7 @@
             (let [event #{{:changed-path canary-file
                             :type :create}}]
               (spit nested-file "foo") ;; expect no events from
-              (spit canary-file "foo") ;; control
+              (fs/touch canary-file) ;; control
               (is (= event (wait-for-exactly-event results event)))))
 
           (reset! results [])

--- a/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
@@ -281,7 +281,7 @@
     (with-app-with-config
      app [filesystem-watch-service] {}
      (let [service (tk-app/get-service app :FilesystemWatchService)
-           watcher (create-watcher service)
+           watcher (create-watcher service {:recursive false})
            results (atom [])
            callback (make-callback results)
            root-dir (fs/temp-dir "root-dir")
@@ -289,7 +289,7 @@
            nested-dir (fs/file intermediate-dir "nested-dir")
            canary-file (fs/file root-dir "canary")]
 
-      (add-watch-dir! watcher root-dir {:recursive false})
+      (add-watch-dir! watcher root-dir)
       (add-callback! watcher callback)
        ;; basic smoke test - ensure with recursive off we haven't broken expected event watching
       (testing "expect events from"
@@ -564,19 +564,16 @@
     (with-app-with-config
      app [filesystem-watch-service] {}
      (let [service (tk-app/get-service app :FilesystemWatchService)
-           watcher (create-watcher service)
+           watcher (create-watcher service {:recursive false})
            results (atom [])
            callback (make-callback results)
            first-dir (fs/temp-dir "first")
-           second-dir (fs/temp-dir "second")
-           third-dir (fs/temp-dir "third")]
-
-      (add-watch-dir! watcher first-dir {:recursive false})
+           second-dir (fs/temp-dir "second")]
       ;; adding another directory with the same recursive value is OK
-      (add-watch-dir! watcher second-dir {:recursive false})
+      (add-watch-dir! watcher first-dir {:recursive false})
       ;; but adding another directory with a different recursive value should fail
       (is (thrown-with-msg? IllegalArgumentException #"cannot change to :recursive true"
-            (add-watch-dir! watcher third-dir {:recursive true})))))))
+            (add-watch-dir! watcher second-dir {:recursive true})))))))
 
 ;; Here we create a stub object that implements the WatchEvent interface as
 ;; the concrete class is a private inner class. See:

--- a/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
@@ -251,6 +251,40 @@
                              :type :delete}}]
                (is (= events (wait-for-events results events)))))))))))
 
+(deftest ^:integration recurse-false-test
+  (testing "Watching of nested directories with recursive disabled"
+    (with-app-with-config
+     app [filesystem-watch-service] {}
+     (let [service (tk-app/get-service app :FilesystemWatchService)
+           watcher (create-watcher service)
+           results (atom [])
+           callback (make-callback results)
+           root-dir (fs/temp-dir "root-dir")
+           intermediate-dir (fs/file root-dir "intermediate-dir")
+           nested-dir (fs/file intermediate-dir "nested-dir")
+           canary-file (fs/file root-dir "canary")]
+
+      (add-watch-dir! watcher root-dir {:recursive false})
+       ;; with recursive off, we do still expect events to fire for these
+      (testing "expect events from"
+        (testing "creating an intermediate directory")
+        (testing "modifying intermediate directory")
+        (testing "deleting intermediate directory")
+
+        (testing "creating a file in root directory")
+        (testing "modifying a file in root directory")
+        (testing "deleting a file in root directory"))
+
+        ;; we expect no events to fire from any of these actions
+      (testing "expect no events from"
+        (testing "creating a file in intermediate directory")
+        (testing "modifying a file in intermediate directory")
+        (testing "deleting a file in intermedidate directory")
+
+        (testing "creating a directory in an intermediate directory")
+        (testing "modifying a directory in an intermediate directory")
+        (testing "deleting a directory in an intermediate directory"))))))
+
 (deftest ^:integration multiple-watch-dirs-test
   (testing "Watching of multiple directories using a single watcher"
     (with-app-with-config

--- a/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
@@ -20,14 +20,14 @@
     (swap! dest concat events)))
 
 (defn contains-events?
-  ([dest events]
-   (let [select-keys-set (set (map #(select-keys % [:changed-path :type]) @dest))]
-     (set/subset? events select-keys-set))))
+  [dest events]
+  (let [select-keys-set (set (map #(select-keys % [:changed-path :type]) @dest))]
+     (set/subset? events select-keys-set)))
 
 (defn exactly-matches-event?
   [dest expected-event]
-   (let [select-keys-set (set (map #(select-keys % [:changed-path :type]) @dest))]
-     (= expected-event select-keys-set)))
+  (let [select-keys-set (set (map #(select-keys % [:changed-path :type]) @dest))]
+    (= expected-event select-keys-set)))
 
 
 (def wait-time
@@ -57,7 +57,6 @@
   (let [start-time (System/currentTimeMillis)]
     (loop []
       (let [elapsed-time (- (System/currentTimeMillis) start-time)]
-
         (if-not (empty? @dest)
           (if (exactly-matches-event? dest expected-event)
             expected-event
@@ -279,8 +278,8 @@
 (deftest ^:integration recurse-false-test
   (testing "Watching of nested directories with recursive disabled"
     (with-app-with-config
-     app [filesystem-watch-service] {}
-     (let [service (tk-app/get-service app :FilesystemWatchService)
+      app [filesystem-watch-service] {}
+      (let [service (tk-app/get-service app :FilesystemWatchService)
            watcher (create-watcher service {:recursive false})
            results (atom [])
            callback (make-callback results)
@@ -572,7 +571,9 @@
       ;; adding another directory with the same recursive value is OK
       (add-watch-dir! watcher first-dir {:recursive false})
       ;; but adding another directory with a different recursive value should fail
-      (is (thrown-with-msg? IllegalArgumentException #"cannot change to :recursive true"
+      (is (thrown-with-msg?
+            IllegalArgumentException
+            #"cannot change to :recursive true"
             (add-watch-dir! watcher second-dir {:recursive true})))))))
 
 ;; Here we create a stub object that implements the WatchEvent interface as

--- a/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_service_test.clj
@@ -55,17 +55,16 @@
   event. If so, returns the expected event. Otherwise returns contents of dest."
   [dest expected-event]
   (let [start-time (System/currentTimeMillis)]
-    (loop []
-      (let [elapsed-time (- (System/currentTimeMillis) start-time)]
-        (if-not (empty? @dest)
-          (if (exactly-matches-event? dest expected-event)
-            expected-event
-            @dest)
-          (if (< elapsed-time wait-time)
-            (recur)
-            (do
-              (println "timed-out waiting for events")
-              @dest)))))))
+    (loop [elapsed-time 0]
+      (if-not (empty? @dest)
+        (if (exactly-matches-event? dest expected-event)
+          expected-event
+          @dest)
+        (if (< elapsed-time wait-time)
+          (recur (- (System/currentTimeMillis) start-time))
+          (do
+            (println "timed-out waiting for events")
+            @dest))))))
 
 (defn watch!*
   [watcher root callback]


### PR DESCRIPTION
* For the watcher protocol implementation, add a new field `recursive`. The field is initially populated as an atom with a nil value. Upon the first watch directory added, the field is set "permanently" to the value specified for the  :recursive option. We do so by enforcing that upon addition of any new directories to watch, the :recursive option must be the same as previously supplied, or we throw an exception. Also add a docstring to watch-new-directories! to clarify its behavior.

* Plumb recursive option through service. Update the required methods in the watch service to take the recursive setting into acount when deciding whether or not to recurse into directories that are watched and add them to the list of watched directories. With this, if a user specificies :recursive false, we limit watching to only the directory specified by `add-watch-dir!` and no others.

* Add new test utilities that allow us to check if a specific event - and only that event - have been registered by the watch service. We do this by immediately doing our comparison check on the first event that is registered.

  We are in the odd position of needing to test that something -doesn't happen-, not that it does. We can't just test that no events are registered, because that might happen for a number of reasons (ie the underlying watcher service failed). So instead we have a canary event alongside every operation that should not generate an event, and then we check that the only event that is registered is the canary event.
