### PR TITLE
(PE-27497) Continue traversing directory when a file disappears

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: clojure
 lein: 2.7.1
 jdk:
-  - oraclejdk8
+  - openjdk8
 script: ./ext/travisci/test.sh
 notifications:
   email: false

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-lein2 test
+lein test

--- a/src/java/com/puppetlabs/DirWatchUtils.java
+++ b/src/java/com/puppetlabs/DirWatchUtils.java
@@ -49,6 +49,18 @@ public class DirWatchUtils {
                     register(watcher, dir);
                     return FileVisitResult.CONTINUE;
                 }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc)
+                        throws IOException {
+                     if (exc instanceof java.nio.file.NoSuchFileException) {
+                         // The file may have disappeared since we started traversing,
+                         // (e.g. a lockfile getting cleaned up), ignore it and continue.
+                         return FileVisitResult.CONTINUE;
+                     } else {
+                         throw exc;
+                     }
+                }
             });
         }
     }


### PR DESCRIPTION
This commit updates our FileVisitor to continue iterating when it
encounters a file that has disappeared. If we have a watcher on a
directory with files managed by Puppet, there's a chance that we
might iterate over it while the file is being replaced, which
creates and then destroys a lockfile. Previously, this would cause the
Visitor to throw an exception, so this commit squashes that exception.

This is a cherry-pick of 0ff6c649a4b5e08b565800beb846263f5e72e3a2.