### PR TITLE
(PE-27497) Rescue NoSuchFileException when registering

### DIFF
--- a/src/java/com/puppetlabs/DirWatchUtils.java
+++ b/src/java/com/puppetlabs/DirWatchUtils.java
@@ -26,11 +26,17 @@ public class DirWatchUtils {
      */
     public static void register(final WatchService watcher,
                                 final Path dir) throws IOException {
-        dir.register(watcher,  new WatchEvent.Kind[]{
-                StandardWatchEventKinds.ENTRY_MODIFY,
-                StandardWatchEventKinds.ENTRY_CREATE,
-                StandardWatchEventKinds.ENTRY_DELETE},
-                SensitivityWatchEventModifier.HIGH);
+	try {
+            dir.register(watcher,  new WatchEvent.Kind[]{
+                    StandardWatchEventKinds.ENTRY_MODIFY,
+                    StandardWatchEventKinds.ENTRY_CREATE,
+                    StandardWatchEventKinds.ENTRY_DELETE},
+                    SensitivityWatchEventModifier.HIGH);
+	} catch (NoSuchFileException ex) {
+	    log.warn(String.format("Failed to register watcher for path '%s'. Encountered error: %s",
+		    dir.toString(),
+		    ex.toString()));
+	}
     }
 
     /**


### PR DESCRIPTION
Some implementations of temporary "files" creates a directory instead of
a true file (mkdir is apparently required on older windows systems for
atomic file creation).  This triggers us to register the directory for
watching when watching the parent directory recursively. This behavior
creates a race condition where the "lockfile" may be deleted while its
registration is pending.

Checking for the file/dirctory to exist within our implementation of
register doesn't really buy us anything since we're called immediately
during the "vistDirectory" action of the FileTreeWalker - ie. it
existed when the previous function was called and the previous function
just defers to us. (This theory holds up during testing)