### PR TITLE
(maint) allow event filtering and file filtering for file watching

### DIFF
--- a/src/clj/puppetlabs/trapperkeeper/services/protocols/filesystem_watch_service.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/protocols/filesystem_watch_service.clj
@@ -25,7 +25,22 @@
     When dir is deleted, the behavior is unspecified, left up to the
     implementation, and may be platform-specific.")
 
-  (add-callback! [this callback]
+  (add-file-callback! [this path-to-file callback] [this path-to-file callback types]
+    "Adds a callback to a Watcher tha will be invoked when the watched file changes.
+    The parent directory containing the file must be added via `add-watch-dir!` for the callbacks to be triggered.
+    The callback will be passed a sequence of Events as its only argument.
+    The exact events passed to the callback are unspecified, left up to the implementation,
+    and possibly platform-dependent; however, the following events are guaranteed to be passed to the callback
+
+     * an event of :type :create with :path p, when a file is created at path p
+     * an event of :type :modify with :path p, when the contents of a file at path p are modified
+     * an event of :type :delete with :path p, when a file is deleted at path p
+
+     The types of events where the callback is triggered can be limited with the optional fourth argument. The fourth
+     argument should be the `set` of types of interest from: `create`, `modify`, `delete`, `unknown`.
+     The default is to specify all types.")
+
+  (add-callback! [this callback] [this callback types]
     "Adds a callback to a Watcher.  The callback will be invoked when any
     watched directories change.  The callback will be passed a sequence of
     Events as its only argument.  The exact events passed to the callback are
@@ -38,7 +53,11 @@
 
     Note that, for any of those particular changes, there may also be additional
     events passed to the callback, such as events on a parent directory of a
-    changed file."))
+    changed file.
+
+    The types of events where the callback is triggered can be limited with the optional third argument.
+    The types argument should be the `set` of types of interest from: `create`, `modify`, `delete`, `unknown`.
+    The default is to specify all types."))
 
 (defprotocol FilesystemWatchService
   (create-watcher [this] [this options]


### PR DESCRIPTION
This adds the ability for a callback to add filtering on specific events, and specific file paths if desired.