### PR TITLE
(maint) update clj-parent to latest, avoid expensive logging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,12 +6,10 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project  {:coords [puppetlabs/clj-parent "7.3.1"]
+  :parent-project  {:coords [puppetlabs/clj-parent "7.3.20"]
                     :inherit [:managed-dependencies]}
 
   :pedantic? :abort
-
-  :exclusions [org.clojure/clojure]
 
   :dependencies [[org.clojure/clojure]
                  [org.clojure/tools.logging]

--- a/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/watcher/filesystem_watch_core.clj
@@ -152,12 +152,16 @@
    events :- [Event]]
   (let [callbacks @(:callbacks watcher)
         events-by-dir (group-by :watched-path events)]
-    (doseq [[dir events'] events-by-dir]
-      (log/debug (trs "Got {0} event(s) in directory {1}"
-                   (count events') dir)))
-    (log/tracef "%s\n%s"
-                (trs "Events:")
-                (ks/pprint-to-string events))
+    ;; avoid doing a potentially expensive walk when we aren't logging at :debug
+    (when (log/enabled? :debug)
+      (doseq [[dir events'] events-by-dir]
+        (log/debug (trs "Got {0} event(s) in directory {1}"
+                     (count events') dir))))
+    ;; avoid doing a potentially expensive print-to-string when we aren't logging at :trace
+    (when (log/enabled? :trace)
+      (log/tracef "%s\n%s"
+                  (trs "Events:")
+                  (ks/pprint-to-string events)))
     (doseq [callback callbacks]
       (callback events))))
 


### PR DESCRIPTION
This updates clj-parent to 4.20 and removes an exclusion for clojure.

It also conditionalizes some potentially expensive logging when the logging levels aren't used. Specifically it avoids a `doseq` and `count` of the events (which can be thousands as seen in the field) when debug isn't enabled, and avoids a potentially expensive `print-to-string` when trace isn't enabled.